### PR TITLE
Run CI also for PRs

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -9,6 +9,7 @@ on:
       - '*.yml'
     branches:
       - master
+  pull_request:
 
 jobs:
   linux:


### PR DESCRIPTION
In my other PR (https://github.com/kotest/kotest-examples/pull/66) I was surprised that CI doesn't validate the change. It turned out CI works only on pushing to `master` we could make this repo more contributor-friendly if we enable CI for PRs.